### PR TITLE
minor logging changes if training from a checkpoint

### DIFF
--- a/training.py
+++ b/training.py
@@ -50,10 +50,10 @@ def train(model, train_dataloader, epochs, lr, steps_til_summary, epochs_til_che
     writer = SummaryWriter(summaries_dir)
 
     total_steps = 0
-    with tqdm(total=len(train_dataloader) * epochs) as pbar:
+    with tqdm(total=len(train_dataloader) * (epochs - start_epoch)) as pbar:
         train_losses = []
         for epoch in range(start_epoch, epochs):
-            if not epoch % epochs_til_checkpoint and epoch:
+            if not epoch % epochs_til_checkpoint and epoch != start_epoch:
                 # Saving the optimizer state is important to produce consistent results
                 checkpoint = { 
                     'epoch': epoch,


### PR DESCRIPTION
- __Line 53__: If one were to train a model with a total of 100k epochs starting from a checkpoint of 25k epochs, the current code would display a status bar that runs from 0 to 100k. That would provide an inaccurate estimate of the remaining time, because there are actually only 75k epochs to run. This edit changes the status bar so it goes from `0` to `epochs - start_epoch`, which in this example would be 0 to 75k.

- __Line 56__: When starting from a checkpoint other than 0, the checkpoint will almost always satisfy the two conditions `not epoch % epochs_til_checkpoint and epoch`, so the current code would save a checkpoint before actually doing any training. Among other things, this overwrites the training losses file at the the starting checkpoint, replacing it with an empty file. Replacing the condition `epoch` with the condition `epoch != start_epoch` should fix that problem.